### PR TITLE
Mention `--recurse-submodules`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ testext
 test/python/__pycache__/
 .Rhistory
 .Rproj.user
+vcpkg/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ duckdb_unittest_tempdir/
 testext
 test/python/__pycache__/
 .Rhistory
+.Rproj.user

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ This extension, Quack, allow you to ... <extension_goal>.
 
 
 ## Building
+
+### Getting started
+
+First step is to clone this repo and make sure you pull in 
+DuckDB by using `--recurse-submodules`: 
+
+```shell
+git clone --recurse-submodules https://github.com/<you>/duckdb-rfuns.git
+```
+
 ### Managing dependencies
 DuckDB extensions uses VCPKG for dependency management. Enabling VCPKG is very simple: follow the [installation instructions](https://vcpkg.io/en/getting-started) or just run the following:
 ```shell


### PR DESCRIPTION
When I initially tried to build this with `make` there was an error message because the `duckdb` directory did not have a `CMakeList` file, because the directory had not been downloaded ...

This is borrowed from https://github.com/duckdb/extension-template#getting-started

I can remove changes to the `.gitignore` but I believe them to be harmless. Should we also ignore the `duckdb-rfuns.Rproj` that got created when opening the repo with Rstudio ?