### PR TITLE
`==` for `lgl, int, dbl and str`

### DIFF
--- a/duckdb-rfuns.Rproj
+++ b/duckdb-rfuns.Rproj
@@ -1,0 +1,15 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Makefile

--- a/src/add.cpp
+++ b/src/add.cpp
@@ -40,17 +40,17 @@ static void BaseRAddFunctionDouble(DataChunk &args, ExpressionState &state, Vect
 		    return left + right;
 	    });
 }
-}
+} // namespace
 
 ScalarFunctionSet base_r_add() {
-    ScalarFunctionSet set("r_base::+");
+	ScalarFunctionSet set("r_base::+");
 	set.AddFunction(
 	    ScalarFunction({LogicalType::INTEGER, LogicalType::INTEGER}, LogicalType::INTEGER, BaseRAddFunctionInteger));
 	set.AddFunction(
 	    ScalarFunction({LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE, BaseRAddFunctionDouble));
 
-    return set;
+	return set;
 }
 
-}
-}
+} // namespace rfuns
+} // namespace duckdb

--- a/src/eq.cpp
+++ b/src/eq.cpp
@@ -109,6 +109,28 @@ static void BaseREqFunctionIntegerString(DataChunk &args, ExpressionState &state
 	                                                        &ExecuteBaseREqFunctionStringInteger);
 }
 
+static bool ExecuteBaseREqFunctionStringBoolean(string_t left, bool right) {
+	return left == (right ? "TRUE" : "FALSE");
+}
+
+static void BaseREqFunctionStringBoolean(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto parts = EqTypeAssert<LogicalType::VARCHAR, LogicalType::BOOLEAN>(args);
+    
+	return BinaryExecutor::Execute<string_t, bool, bool>(
+        parts.lefts, parts.rights, result, args.size(),
+	    &ExecuteBaseREqFunctionStringBoolean
+    );
+}
+
+static void BaseREqFunctionBooleanString(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto parts = EqTypeAssert<LogicalType::BOOLEAN, LogicalType::VARCHAR>(args);
+    
+	return BinaryExecutor::Execute<string_t, bool, bool>(
+        parts.rights, parts.lefts, result, args.size(),
+	    &ExecuteBaseREqFunctionStringBoolean
+    );
+}
+
 static bool ExecuteBaseREqFunctionStringDouble(string_t left, double right) {
 	char right_chr[100];
 	snprintf(right_chr, sizeof(right_chr), "%.17g", right);
@@ -145,10 +167,17 @@ ScalarFunctionSet base_r_eq() {
     set.AddFunction(ScalarFunction({LogicalType::DOUBLE, LogicalType::BOOLEAN}, LogicalType::BOOLEAN, BaseREqFunctionDoubleInteger<LogicalType::BOOLEAN>));
     set.AddFunction(ScalarFunction({LogicalType::BOOLEAN, LogicalType::DOUBLE}, LogicalType::BOOLEAN, BaseREqFunctionIntegerDouble<LogicalType::BOOLEAN>));
 
+    // string == int 
+    set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER}, LogicalType::BOOLEAN, BaseREqFunctionStringInteger));
+	set.AddFunction(ScalarFunction({LogicalType::INTEGER, LogicalType::VARCHAR}, LogicalType::BOOLEAN, BaseREqFunctionIntegerString));
+	
+    // string == lgl
+    set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BOOLEAN}, LogicalType::BOOLEAN, BaseREqFunctionStringBoolean));
+	set.AddFunction(ScalarFunction({LogicalType::BOOLEAN, LogicalType::VARCHAR}, LogicalType::BOOLEAN, BaseREqFunctionBooleanString));
+	
+
 	set.AddFunction(ScalarFunction({LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::BOOLEAN, BaseREqFunctionDouble));
 	set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN, BaseREqFunctionString));
-	set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER}, LogicalType::BOOLEAN,BaseREqFunctionStringInteger));
-	set.AddFunction(ScalarFunction({LogicalType::INTEGER, LogicalType::VARCHAR}, LogicalType::BOOLEAN,BaseREqFunctionIntegerString));
 	set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::DOUBLE}, LogicalType::BOOLEAN, BaseREqFunctionStringDouble));
 	set.AddFunction(ScalarFunction({LogicalType::DOUBLE, LogicalType::VARCHAR}, LogicalType::BOOLEAN, BaseREqFunctionDoubleString));
 

--- a/src/include/rfuns_extension.hpp
+++ b/src/include/rfuns_extension.hpp
@@ -8,7 +8,7 @@ namespace rfuns {
 ScalarFunctionSet base_r_add();
 ScalarFunctionSet base_r_eq();
 
-}
+} // namespace rfuns
 
 class RfunsExtension : public Extension {
 public:

--- a/src/rfuns_extension.cpp
+++ b/src/rfuns_extension.cpp
@@ -23,7 +23,7 @@ inline void RfunsScalarFun(DataChunk &args, ExpressionState &state, Vector &resu
 static void LoadInternal(DatabaseInstance &instance) {
 	ExtensionUtil::RegisterFunction(instance, rfuns::base_r_add());
 	ExtensionUtil::RegisterFunction(instance, rfuns::base_r_eq());
-	
+
 	// Register a scalar function
 	auto rfuns_scalar_function = ScalarFunction("rfuns", {LogicalType::VARCHAR}, LogicalType::VARCHAR, RfunsScalarFun);
 	ExtensionUtil::RegisterFunction(instance, rfuns_scalar_function);

--- a/test/sql/rfuns.test
+++ b/test/sql/rfuns.test
@@ -164,6 +164,30 @@ NULL
 NULL
 NULL
 
+# Equality for doubles with integer
+query III
+SELECT
+	"r_base::=="(2.0, 2),
+	"r_base::=="(3.5, 2),
+	NULL
+	;
+----
+TRUE
+FALSE
+NULL
+
+# Equality for integer with double
+query III
+SELECT
+	"r_base::=="(2, 2.0),
+	"r_base::=="(2, 3.5),
+	NULL
+	;
+----
+TRUE
+FALSE
+NULL
+
 # Equality for strings
 query IIIII
 SELECT

--- a/test/sql/rfuns.test
+++ b/test/sql/rfuns.test
@@ -70,6 +70,84 @@ NULL
 NULL
 NULL
 
+# Equality for booleans
+query IIIIIIIIII
+SELECT
+	"r_base::=="(TRUE, TRUE),
+	"r_base::=="(TRUE, FALSE),
+	"r_base::=="(FALSE, TRUE),
+	"r_base::=="(FALSE, FALSE),
+	"r_base::=="(NULL, FALSE),
+	"r_base::=="(NULL, TRUE),
+	"r_base::=="(TRUE, NULL),
+	"r_base::=="(FALSE, NULL),
+	"r_base::=="(NULL, NULL),
+	NULL
+	;
+----
+TRUE
+FALSE
+FALSE
+TRUE
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+
+# Equality for integers with boolean
+query IIIIIIIIII
+SELECT
+	"r_base::=="(1   , TRUE),
+	"r_base::=="(1   , FALSE),
+	"r_base::=="(2   , TRUE),
+	"r_base::=="(2   , FALSE),
+	"r_base::=="(0   , TRUE),
+	"r_base::=="(0   , FALSE),
+	"r_base::=="(NULL, TRUE),
+	"r_base::=="(NULL, NULL),
+	"r_base::=="(42  , NULL),
+	NULL
+	;
+----
+TRUE
+FALSE
+FALSE
+FALSE
+FALSE
+TRUE
+NULL
+NULL
+NULL
+NULL
+
+# Equality for boolean with integer
+query IIIIIIIIII
+SELECT
+	"r_base::=="(TRUE , 1),
+	"r_base::=="(FALSE, 1),
+	"r_base::=="(TRUE , 2),
+	"r_base::=="(FALSE, 2),
+	"r_base::=="(TRUE , 0),
+	"r_base::=="(FALSE, 0),
+	"r_base::=="(TRUE , NULL),
+	"r_base::=="(NULL , NULL),
+	"r_base::=="(NULL , 42),
+	NULL
+	;
+----
+TRUE
+FALSE
+FALSE
+FALSE
+FALSE
+TRUE
+NULL
+NULL
+NULL
+NULL
+
 # Equality for doubles
 query IIIII
 SELECT

--- a/test/sql/rfuns.test
+++ b/test/sql/rfuns.test
@@ -236,9 +236,30 @@ TRUE
 FALSE
 FALSE
 TRUE
+FALSE
+FALSE
 NULL
+
+# Equality for booleans with strings
+query IIIIIII
+SELECT
+	"r_base::=="(TRUE, 'TRUE'),
+	"r_base::=="(FALSE, 'TRUE'),
+	"r_base::=="(TRUE, 'FALSE'),
+	"r_base::=="(FALSE, 'FALSE'),
+	"r_base::=="(TRUE, 'tRue'),
+	"r_base::=="(FALSE, 'fAlse'),
+	NULL
+	;
+----
+TRUE
+FALSE
+FALSE
+TRUE
+FALSE
+FALSE
 NULL
-NULL
+
 
 # Equality for strings with doubles
 query III

--- a/test/sql/rfuns.test
+++ b/test/sql/rfuns.test
@@ -220,6 +220,26 @@ NULL
 NULL
 NULL
 
+# Equality for strings with booleans
+query IIIIIII
+SELECT
+	"r_base::=="('TRUE', TRUE),
+	"r_base::=="('TRUE', FALSE),
+	"r_base::=="('FALSE', TRUE),
+	"r_base::=="('FALSE', FALSE),
+	"r_base::=="('tRue', TRUE),
+	"r_base::=="('fAlse', FALSE),
+	NULL
+	;
+----
+TRUE
+FALSE
+FALSE
+TRUE
+NULL
+NULL
+NULL
+
 # Equality for strings with doubles
 query III
 SELECT

--- a/test/sql/rfuns.test
+++ b/test/sql/rfuns.test
@@ -164,26 +164,42 @@ NULL
 NULL
 NULL
 
-# Equality for doubles with integer
-query III
+# Equality for doubles with integer or boolean
+query IIIIIII
 SELECT
 	"r_base::=="(2.0, 2),
 	"r_base::=="(3.5, 2),
+	"r_base::=="(1.0, TRUE),
+	"r_base::=="(1.0, FALSE),
+	"r_base::=="(0.0, FALSE),
+	"r_base::=="(0.0, TRUE),
 	NULL
 	;
 ----
 TRUE
 FALSE
+TRUE
+FALSE
+TRUE
+FALSE
 NULL
 
-# Equality for integer with double
-query III
+# Equality for integer or boolean with double
+query IIIIIII
 SELECT
 	"r_base::=="(2, 2.0),
 	"r_base::=="(2, 3.5),
+	"r_base::=="(TRUE, 1.0),
+	"r_base::=="(FALSE, 1.0),
+	"r_base::=="(FALSE, 0.0),
+	"r_base::=="(TRUE, 0.0),
 	NULL
 	;
 ----
+TRUE
+FALSE
+TRUE
+FALSE
 TRUE
 FALSE
 NULL


### PR DESCRIPTION
👶 steps. I'm not sure why we get `<int>` when `NULL` are involved: 

``` r
pillar::glimpse(dbGetQuery(con, r"[
SELECT
    "r_base::=="(1, TRUE),
    "r_base::=="(1, FALSE),
    "r_base::=="(2, TRUE),
    "r_base::=="(2, FALSE),
    "r_base::=="(0, TRUE),
    "r_base::=="(0, FALSE),
    "r_base::=="(NULL, TRUE),
    NULL
]"))
#> Rows: 1
#> Columns: 8
#> $ `r_base::==(1, CAST('t' AS BOOLEAN))`    <lgl> TRUE
#> $ `r_base::==(1, CAST('f' AS BOOLEAN))`    <lgl> FALSE
#> $ `r_base::==(2, CAST('t' AS BOOLEAN))`    <lgl> FALSE
#> $ `r_base::==(2, CAST('f' AS BOOLEAN))`    <lgl> FALSE
#> $ `r_base::==(0, CAST('t' AS BOOLEAN))`    <lgl> FALSE
#> $ `r_base::==(0, CAST('f' AS BOOLEAN))`    <lgl> TRUE
#> $ `r_base::==(NULL, CAST('t' AS BOOLEAN))` <int> NA
#> $ `NULL`                                   <int> NA
```

<sup>Created on 2024-01-23 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>